### PR TITLE
Redo unix escaping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,35 +89,43 @@ pub mod windows {
 pub mod unix {
     use std::borrow::Cow;
 
-    const SHELL_SPECIAL: &'static str = r#" \$'"`!"#;
+    fn non_whitelisted(ch: char) -> bool {
+        match ch {
+            'a'...'z' | 'A'...'Z' | '0'...'9' | '-' | '_' | '=' => false,
+            _ => true,
+        }
+    }
 
     /// Escape characters that may have special meaning in a shell, including spaces.
     pub fn escape(s: Cow<str>) -> Cow<str> {
-        let escape_char = '\\';
-        // check if string needs to be escaped
-        let clean = SHELL_SPECIAL.chars().all(|sp_char| !s.contains(sp_char));
-        if clean {
-            return s
+        if !s.contains(non_whitelisted) {
+            return s;
         }
-        let mut es = String::with_capacity(s.len());
+
+        let mut es = String::with_capacity(s.len() + 2);
+        es.push('\'');
         for ch in s.chars() {
-            if SHELL_SPECIAL.contains(ch) {
-                es.push(escape_char);
+            if ch == '\'' {
+                es.push_str("'\\''");
+            } else {
+                es.push(ch);
             }
-            es.push(ch)
         }
+        es.push('\'');
         es.into()
     }
 
     #[test]
     fn test_escape() {
+        assert_eq!(escape("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=".into()),
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=");
         assert_eq!(escape("--aaa=bbb-ccc".into()), "--aaa=bbb-ccc");
         assert_eq!(escape("linker=gcc -L/foo -Wl,bar".into()),
-        r#"linker=gcc\ -L/foo\ -Wl,bar"#);
+        r#"'linker=gcc -L/foo -Wl,bar'"#);
         assert_eq!(escape(r#"--features="default""#.into()),
-        r#"--features=\"default\""#);
+        r#"'--features="default"'"#);
         assert_eq!(escape(r#"'!\$`\\\n "#.into()),
-        r#"\'\!\\\$\`\\\\\\n\ "#);
+        r#"''\''!\$`\\\n '"#);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,13 @@ pub mod unix {
         let mut es = String::with_capacity(s.len() + 2);
         es.push('\'');
         for ch in s.chars() {
-            if ch == '\'' {
-                es.push_str("'\\''");
-            } else {
-                es.push(ch);
+            match ch {
+                '\'' | '!' => {
+                    es.push_str("'\\");
+                    es.push(ch);
+                    es.push('\'');
+                }
+                _ => es.push(ch),
             }
         }
         es.push('\'');
@@ -120,12 +123,9 @@ pub mod unix {
         assert_eq!(escape("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=".into()),
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=");
         assert_eq!(escape("--aaa=bbb-ccc".into()), "--aaa=bbb-ccc");
-        assert_eq!(escape("linker=gcc -L/foo -Wl,bar".into()),
-        r#"'linker=gcc -L/foo -Wl,bar'"#);
-        assert_eq!(escape(r#"--features="default""#.into()),
-        r#"'--features="default"'"#);
-        assert_eq!(escape(r#"'!\$`\\\n "#.into()),
-        r#"''\''!\$`\\\n '"#);
+        assert_eq!(escape("linker=gcc -L/foo -Wl,bar".into()), r#"'linker=gcc -L/foo -Wl,bar'"#);
+        assert_eq!(escape(r#"--features="default""#.into()), r#"'--features="default"'"#);
+        assert_eq!(escape(r#"'!\$`\\\n "#.into()), r#"''\'''\!'\$`\\\n '"#);
     }
 }
 


### PR DESCRIPTION
Switch to single quoting the input with a whitelist of characters known
to not need escaping.

Closes #1 

Does this seem reasonable @joshtriplett?

Also cc @alexcrichton to make sure this won't break anything in cargo.