### PR TITLE
Whitelist +

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub mod unix {
 
     fn non_whitelisted(ch: char) -> bool {
         match ch {
-            'a'...'z' | 'A'...'Z' | '0'...'9' | '-' | '_' | '=' | '/' | ',' | '.' => false,
+            'a'...'z' | 'A'...'Z' | '0'...'9' | '-' | '_' | '=' | '/' | ',' | '.' | '+' => false,
             _ => true,
         }
     }
@@ -121,8 +121,9 @@ pub mod unix {
     #[test]
     fn test_escape() {
         assert_eq!(
-            escape("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.".into()),
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.");
+            escape("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.+".into()),
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=/,.+"
+        );
         assert_eq!(escape("--aaa=bbb-ccc".into()), "--aaa=bbb-ccc");
         assert_eq!(escape("linker=gcc -L/foo -Wl,bar".into()), r#"'linker=gcc -L/foo -Wl,bar'"#);
         assert_eq!(escape(r#"--features="default""#.into()), r#"'--features="default"'"#);


### PR DESCRIPTION
`+` doesn't have a special meaning in any mainstream shell as far as I can tell.  I have a case where a path like `/usr/include/c++` is unnecessarily quoted.