### PR TITLE
Fix ellipsis inclusive range pattern. "..." is no longer supported.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub mod unix {
 
     fn non_whitelisted(ch: char) -> bool {
         match ch {
-            'a'...'z' | 'A'...'Z' | '0'...'9' | '-' | '_' | '=' | '/' | ',' | '.' | '+' => false,
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '=' | '/' | ',' | '.' | '+' => false,
             _ => true,
         }
     }
@@ -132,4 +132,3 @@ pub mod unix {
         assert_eq!(escape("".into()), r#"''"#);
     }
 }
-


### PR DESCRIPTION
This fixes warning:

```
warning: `...` range patterns are deprecated
  --> /Users/oherrala/.cargo/registry/src/github.com-1ecc6299db9ec823/shell-escape-0.1.5/src/lib.rs:95:16
   |
95 |             'a'...'z' | 'A'...'Z' | '0'...'9' | '-' | '_' | '=' | '/' | ',' | '.' | '+' => false,
   |                ^^^ help: use `..=` for an inclusive range
   |
   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
   = note: `#[warn(ellipsis_inclusive_range_patterns)]` on by default
```